### PR TITLE
Fix stdout mushing with analysis command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
 "Homepage" = "https://github.com/OpenFreeEnergy/openfe_analysis"
 
 [project.scripts]
-openfe_analysis = "openfe_analysis.cli:main"
+openfe_analysis = "openfe_analysis.cli:cli"
 
 [tool.versioningit]
 default-version = "1+unknown"

--- a/src/openfe_analysis/cli.py
+++ b/src/openfe_analysis/cli.py
@@ -5,13 +5,18 @@ import pathlib
 from . import rmsd
 
 
-@click.command
+@click.group()
+def cli():
+    pass
+
+
+@cli.command(name="RFE_analysis")
 @click.argument('loc', type=click.Path(exists=True,
                                        readable=True,
                                        file_okay=False,
                                        dir_okay=True,
                                        path_type=pathlib.Path))
-def main(loc):
+def rfe_analysis(loc):
     pdb = loc / "hybrid_system.pdb"
     trj = loc / "simulation.nc"
 

--- a/src/openfe_analysis/cli.py
+++ b/src/openfe_analysis/cli.py
@@ -16,9 +16,14 @@ def cli():
                                        file_okay=False,
                                        dir_okay=True,
                                        path_type=pathlib.Path))
-def rfe_analysis(loc):
+@click.argument('output', type=click.Path(writable=True,
+                                          dir_okay=False,
+                                          path_type=pathlib.Path))
+def rfe_analysis(loc, output):
     pdb = loc / "hybrid_system.pdb"
     trj = loc / "simulation.nc"
 
     data = rmsd.gather_rms_data(pdb, trj)
-    click.echo(json.dumps(data))
+
+    with click.open_file(output, 'w') as f:
+        f.write(json.dumps(data))


### PR DESCRIPTION
make `openfe_analysis` hold a group of different commands

make the RFE_analysis command require an output location