### PR TITLE
Fix nsteps reading

### DIFF
--- a/src/openfe_analysis/handle_trajectories.py
+++ b/src/openfe_analysis/handle_trajectories.py
@@ -77,7 +77,7 @@ def _create_new_dataset(filename: Path, n_atoms: int,
         AMBER Conventions compliant NetCDF dataset to store information
         contained in MultiState reporter generated NetCDF file.
     """
-    ncfile = nc.Dataset(filename, 'w', format='NETCDF3_64BIT')
+    ncfile = nc.Dataset(filename, 'w', format='NETCDF3_64BIT_OFFSET')
     ncfile.Conventions = 'AMBER'
     ncfile.ConventionVersion = "1.0"
     ncfile.application = "openfe_analysis"


### PR DESCRIPTION
Fixes #38 #33

Fix the reading of nsteps from the netcdf file by accessing `mcmc_moves`.