### PR TITLE
drop python 3.10 and macos-13 from ci runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: |
-            # linux cache location
-            ~/.cache/openfe
-            # osx cache location
-            ~/Library/Caches/openfe
+            ~/.cache/openfe_analysis/
           key: ${{ runner.os }}
 
       - name: "Test imports"
@@ -76,10 +73,7 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: |
-            # linux cache location
-            ~/.cache/openfe
-            # osx cache location
-            ~/Library/Caches/openfe
+            ~/.cache/openfe_analysis/
           key: ${{ runner.os }}
 
       - name: codecov


### PR DESCRIPTION
SPEC0 has dropped 3.10 for a while now, plus github no longer supports macos-13 runners
