### PR TITLE
Refactor alignment to allow passing through a list of ligands (for SepTop)

### DIFF
--- a/src/openfe_analysis/rmsd.py
+++ b/src/openfe_analysis/rmsd.py
@@ -10,7 +10,10 @@ from MDAnalysis.analysis import rms
 from MDAnalysis.analysis.base import AnalysisBase
 from rdkit import Chem
 
-from .utils.apply_transformations import apply_alignment_transformations
+from .utils.apply_transformations import (
+    apply_complex_alignment_transformations,
+    apply_ligand_alignment_transformations,
+)
 from .utils.universe_utils import create_universe_single_state
 
 
@@ -334,7 +337,14 @@ def gather_rms_data(
             prot = universe.select_atoms(protein_selection)
             ligand = universe.select_atoms(ligand_selection)
 
-            apply_alignment_transformations(universe, prot, ligand)
+            if prot:
+                apply_complex_alignment_transformations(
+                    universe,
+                    protein=prot,
+                    ligands=[ligand] if ligand.n_atoms > 0 else None,
+                )
+            elif ligand.n_atoms > 0:
+                apply_ligand_alignment_transformations(universe, ligand=ligand)
 
             if prot:
                 prot_rmsd = RMSDAnalysis(prot).run(step=skip)

--- a/src/openfe_analysis/tests/conftest.py
+++ b/src/openfe_analysis/tests/conftest.py
@@ -1,8 +1,10 @@
 import pathlib
 from importlib import resources
 
+import numpy as np
 import pooch
 import pytest
+from rdkit import Chem
 
 ZENODO_DOI = "doi:10.5281/zenodo.18378051"
 
@@ -69,3 +71,20 @@ def mcmc_serialized():
         "n_steps: 625\nreassign_velocities: false\n"
         "timestep: !Quantity\n  unit: femtosecond\n  value: 4\n"
     )
+
+
+@pytest.fixture(scope="session")
+def septop_data_dir():
+    return pathlib.Path("data/openfe_analysis_septop")
+
+
+@pytest.fixture(scope="session")
+def septop_complex_data(septop_data_dir):
+    return {
+        "pdb": septop_data_dir / "alchemical_system.pdb",
+        "nc": septop_data_dir / "complex.nc",
+        "ligand_A_indices": np.load(septop_data_dir / "ligand_A_indices.npy").tolist(),
+        "ligand_B_indices": np.load(septop_data_dir / "ligand_B_indices.npy").tolist(),
+        "rdmol_A": Chem.SDMolSupplier(str(septop_data_dir / "ligand_A.sdf"), removeHs=False)[0],
+        "rdmol_B": Chem.SDMolSupplier(str(septop_data_dir / "ligand_B.sdf"), removeHs=False)[0],
+    }

--- a/src/openfe_analysis/tests/conftest.py
+++ b/src/openfe_analysis/tests/conftest.py
@@ -6,11 +6,12 @@ import pooch
 import pytest
 from rdkit import Chem
 
-ZENODO_DOI = "doi:10.5281/zenodo.18378051"
+ZENODO_DOI = "doi:10.5281/zenodo.20442933"
 
 ZENODO_FILES = {
     "openfe_analysis_simulation_output.tar.gz": "md5:7f0babaac3dc8f7dd2db63cb79dff00f",
     "openfe_analysis_skipped.tar.gz": "md5:ac42219bde9da3641375adf3a9ddffbf",
+    "openfe_analysis_septop.tar.gz": "md5:8977d86cdbc05767a2e82760bdf9006f",
 }
 
 POOCH_CACHE = pathlib.Path(pooch.os_cache("openfe_analysis"))
@@ -38,6 +39,12 @@ def rbfe_output_data_dir() -> pathlib.Path:
 @pytest.fixture(scope="session")
 def rbfe_skipped_data_dir() -> pathlib.Path:
     cached_dir = _fetch_and_untar("openfe_analysis_skipped")
+    return cached_dir
+
+
+@pytest.fixture(scope="session")
+def septop_data_dir() -> pathlib.Path:
+    cached_dir = _fetch_and_untar("openfe_analysis_septop")
     return cached_dir
 
 
@@ -71,11 +78,6 @@ def mcmc_serialized():
         "n_steps: 625\nreassign_velocities: false\n"
         "timestep: !Quantity\n  unit: femtosecond\n  value: 4\n"
     )
-
-
-@pytest.fixture(scope="session")
-def septop_data_dir():
-    return pathlib.Path("data/openfe_analysis_septop")
 
 
 @pytest.fixture(scope="session")

--- a/src/openfe_analysis/tests/test_gather_rms_data.py
+++ b/src/openfe_analysis/tests/test_gather_rms_data.py
@@ -75,3 +75,20 @@ def test_gather_rms_data_regression_skippednc(simulation_skipped_nc, hybrid_syst
         [1.089747, 1.006143, 1.045068, 1.476353, 1.332893, 1.110507],
         rtol=1e-3,
     )
+
+
+def test_gather_rms_data_ligand_only(simulation_skipped_nc, hybrid_system_skipped_pdb):
+    output = gather_rms_data(
+        hybrid_system_skipped_pdb,
+        simulation_skipped_nc,
+        skip=100,
+        protein_selection="resname DOESNOTEXIST",  # no protein
+    )
+
+    # No protein results
+    assert len(output["protein_RMSD"]) == 0
+    assert len(output["protein_2D_RMSD"]) == 0
+
+    # Ligand results should still be present
+    assert len(output["ligand_RMSD"]) > 0
+    assert len(output["ligand_wander"]) > 0

--- a/src/openfe_analysis/tests/test_rmsd_classes.py
+++ b/src/openfe_analysis/tests/test_rmsd_classes.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 import MDAnalysis as mda
+import netCDF4 as nc
 import numpy as np
 import pytest
 from MDAnalysis.analysis import diffusionmap, rms
@@ -29,7 +30,7 @@ def ligand(hybrid_system_skipped_pdb, simulation_skipped_nc):
     )
     prot = universe.select_atoms("protein and name CA")
     ligand = universe.select_atoms("resname UNK")
-    apply_transformations.apply_alignment_transformations(universe, prot, ligand)
+    apply_transformations.apply_complex_alignment_transformations(universe, prot, [ligand])
     yield universe.select_atoms("resname UNK")
     universe.trajectory.close()
 
@@ -111,6 +112,66 @@ class TestRMSDAnalysis:
             4,
             err_msg="error: rmsd profile should match test values",
         )
+
+    @pytest.mark.parametrize(
+        "state_idx,ligand_key,expected_spike",
+        [
+            (14, "ligand_A_indices", True),
+            (12, "ligand_B_indices", True),
+            (16, "ligand_B_indices", True),
+        ],
+    )
+    def test_separate_ligands_fixes_pbc_spike(
+        self, septop_complex_data, state_idx, ligand_key, expected_spike
+    ):
+        """
+        Regression test for PBC imaging artifact when two ligands are passed
+        as a combined AtomGroup (SepTop case).
+
+        Known problematic states from transformation HIF2a rbfe_1_155:
+        - State 14, ligand A: ~62 A spike at frame 45 (4500 ps)
+        - State 12, ligand B: ~62 A spike at frame 45 (4500 ps)
+        - State 16, ligand B: ~62 A spike at frame 39 (3900 ps)
+
+        Passing ligands separately to apply_complex_alignment_transformations
+        fixes this by imaging each ligand independently relative to the protein.
+        """
+        d = septop_complex_data
+
+        with nc.Dataset(d["nc"]) as ds:
+            if hasattr(ds, "PositionInterval"):
+                n_frames = len(range(0, ds.dimensions["iteration"].size, ds.PositionInterval))
+            else:
+                n_frames = ds.dimensions["iteration"].size
+            skip = max(n_frames // 500, 1)
+
+            # Combined approach should produce a spike
+            u_combined = universe_utils.create_universe_single_state(d["pdb"], ds, state=state_idx)
+            prot = u_combined.select_atoms("protein and name CA")
+            lig_A = u_combined.atoms[np.array(d["ligand_A_indices"])]
+            lig_B = u_combined.atoms[np.array(d["ligand_B_indices"])]
+            lig = u_combined.atoms[np.array(d[ligand_key])]
+
+            apply_transformations.apply_complex_alignment_transformations(
+                u_combined, protein=prot, ligands=[lig_A + lig_B]
+            )
+
+            rmsd_combined = RMSDAnalysis(lig).run(step=skip)
+            assert np.max(rmsd_combined.results.rmsd) > 10.0
+
+            # Separate approach should fix it
+            u_separate = universe_utils.create_universe_single_state(d["pdb"], ds, state=state_idx)
+            prot = u_separate.select_atoms("protein and name CA")
+            lig_A = u_separate.atoms[d["ligand_A_indices"]]
+            lig_B = u_separate.atoms[d["ligand_B_indices"]]
+            lig = u_separate.atoms[d[ligand_key]]
+
+            apply_transformations.apply_complex_alignment_transformations(
+                u_separate, protein=prot, ligands=[lig_A, lig_B]
+            )
+
+            rmsd_separate = RMSDAnalysis(lig).run(step=skip)
+            assert np.max(rmsd_separate.results.rmsd) < 10.0
 
 
 class TestProtein2DRMSD:

--- a/src/openfe_analysis/tests/test_rmsd_classes.py
+++ b/src/openfe_analysis/tests/test_rmsd_classes.py
@@ -114,15 +114,18 @@ class TestRMSDAnalysis:
         )
 
     @pytest.mark.parametrize(
-        "state_idx,ligand_key,expected_spike",
+        "state_idx,ligand_key",
         [
-            (14, "ligand_A_indices", True),
-            (12, "ligand_B_indices", True),
-            (16, "ligand_B_indices", True),
+            (14, "ligand_A_indices"),
+            (12, "ligand_B_indices"),
+            (16, "ligand_B_indices"),
         ],
     )
     def test_separate_ligands_fixes_pbc_spike(
-        self, septop_complex_data, state_idx, ligand_key, expected_spike
+        self,
+        septop_complex_data,
+        state_idx,
+        ligand_key,
     ):
         """
         Regression test for PBC imaging artifact when two ligands are passed
@@ -148,9 +151,9 @@ class TestRMSDAnalysis:
             # Combined approach should produce a spike
             u_combined = universe_utils.create_universe_single_state(d["pdb"], ds, state=state_idx)
             prot = u_combined.select_atoms("protein and name CA")
-            lig_A = u_combined.atoms[np.array(d["ligand_A_indices"])]
-            lig_B = u_combined.atoms[np.array(d["ligand_B_indices"])]
-            lig = u_combined.atoms[np.array(d[ligand_key])]
+            lig_A = u_combined.atoms[d["ligand_A_indices"]]
+            lig_B = u_combined.atoms[d["ligand_B_indices"]]
+            lig = u_combined.atoms[d[ligand_key]]
 
             apply_transformations.apply_complex_alignment_transformations(
                 u_combined, protein=prot, ligands=[lig_A + lig_B]

--- a/src/openfe_analysis/tests/test_transformations.py
+++ b/src/openfe_analysis/tests/test_transformations.py
@@ -104,7 +104,7 @@ def test_chain_radius_of_gyration_stable(universe_single_state):
     """Protein chains should not explode or collapse due to PBC errors
     after applying alignment transformations."""
     protein = universe_single_state.select_atoms("protein and name CA")
-    apply_transformations.apply_alignment_transformations(universe_single_state, protein)
+    apply_transformations.apply_complex_alignment_transformations(universe_single_state, protein)
 
     chain = protein.segments[0].atoms
     rgs = []
@@ -118,7 +118,9 @@ def test_ligand_com_continuity(universe_single_state):
     """Ligand COM should not jump between periodic images after applying
     alignment transformations."""
     ligand = universe_single_state.select_atoms("resname UNK")
-    apply_transformations.apply_alignment_transformations(universe_single_state, ligand=ligand)
+    apply_transformations.apply_ligand_alignment_transformations(
+        universe_single_state, ligand=ligand
+    )
 
     coms = [ligand.center_of_mass() for ts in islice(universe_single_state.trajectory, 20)]
     jumps = [np.linalg.norm(coms[i + 1] - coms[i]) for i in range(len(coms) - 1)]
@@ -153,7 +155,7 @@ def test_multichain_rmsd_shifting(simulation_skipped_nc, hybrid_system_skipped_p
         hybrid_system_skipped_pdb, simulation_skipped_nc, 0
     )
     prot2 = u2.select_atoms("protein and name CA")
-    apply_transformations.apply_alignment_transformations(u2, protein=prot2)
+    apply_transformations.apply_complex_alignment_transformations(u2, protein=prot2)
 
     R2 = rms.RMSD(prot2)
     R2.run()
@@ -165,7 +167,9 @@ def test_multichain_rmsd_shifting(simulation_skipped_nc, hybrid_system_skipped_p
 def test_rmsd_reference_is_first_frame(universe_single_state):
     """After alignment, RMSD at the first frame should be zero."""
     prot = universe_single_state.select_atoms("protein and name CA")
-    apply_transformations.apply_alignment_transformations(universe_single_state, protein=prot)
+    apply_transformations.apply_complex_alignment_transformations(
+        universe_single_state, protein=prot
+    )
 
     _ = next(iter(universe_single_state.trajectory))  # SAFE
     ref = prot.positions.copy()

--- a/src/openfe_analysis/tests/test_transformations.py
+++ b/src/openfe_analysis/tests/test_transformations.py
@@ -1,18 +1,13 @@
-from itertools import islice
-
 import MDAnalysis as mda
 import numpy as np
 import pytest
 from MDAnalysis.analysis import rms
-from MDAnalysis.lib.mdamath import make_whole
-from MDAnalysis.transformations import unwrap
 
 from openfe_analysis.transformations import (
     Aligner,
     ClosestImageShift,
     NoJump,
 )
-from openfe_analysis.utils import apply_transformations, universe_utils
 
 
 @pytest.fixture
@@ -22,15 +17,6 @@ def universe(hybrid_system_skipped_pdb, simulation_skipped_nc):
         simulation_skipped_nc,
         format="MultiStateReporter",
         index=0,
-    )
-    yield u
-    u.trajectory.close()
-
-
-@pytest.fixture
-def universe_single_state(hybrid_system_skipped_pdb, simulation_skipped_nc):
-    u = universe_utils.create_universe_single_state(
-        hybrid_system_skipped_pdb, simulation_skipped_nc, 0
     )
     yield u
     u.trajectory.close()
@@ -98,82 +84,3 @@ def test_aligner(universe):
     # the rmsd should be identical even if the function didn't align
     # as the transformation should have done this
     assert raw_rmsd == pytest.approx(opt_rmsd)
-
-
-def test_chain_radius_of_gyration_stable(universe_single_state):
-    """Protein chains should not explode or collapse due to PBC errors
-    after applying alignment transformations."""
-    protein = universe_single_state.select_atoms("protein and name CA")
-    apply_transformations.apply_complex_alignment_transformations(universe_single_state, protein)
-
-    chain = protein.segments[0].atoms
-    rgs = []
-    for ts in universe_single_state.trajectory[:50]:
-        rgs.append(chain.radius_of_gyration())
-
-    assert np.std(rgs) < 2.0
-
-
-def test_ligand_com_continuity(universe_single_state):
-    """Ligand COM should not jump between periodic images after applying
-    alignment transformations."""
-    ligand = universe_single_state.select_atoms("resname UNK")
-    apply_transformations.apply_ligand_alignment_transformations(
-        universe_single_state, ligand=ligand
-    )
-
-    coms = [ligand.center_of_mass() for ts in islice(universe_single_state.trajectory, 20)]
-    jumps = [np.linalg.norm(coms[i + 1] - coms[i]) for i in range(len(coms) - 1)]
-
-    assert max(jumps) < 5.0
-
-
-def test_multichain_rmsd_shifting(simulation_skipped_nc, hybrid_system_skipped_pdb):
-    """Chain shifting should remove RMSD jumps caused by periodic boundary crossings."""
-    u = universe_utils.create_universe_single_state(
-        hybrid_system_skipped_pdb, simulation_skipped_nc, 0
-    )
-    prot = u.select_atoms("protein and name CA")
-    # Do other transformations, but no shifting
-    unwrap_tr = unwrap(prot)
-    for frag in prot.fragments:
-        make_whole(frag, reference_atom=frag[0])
-    align = Aligner(prot)
-    u.trajectory.add_transformations(unwrap_tr, align)
-    chains = [seg.atoms for seg in prot.segments]
-    assert len(chains) > 1, "Test requires multi-chain protein"
-
-    # RMSD without shifting
-    r = rms.RMSD(prot)
-    r.run()
-    rmsd_no_shift = r.rmsd[:, 2]
-    assert np.max(np.diff(rmsd_no_shift[:20])) > 10  # expect jumps
-    u.trajectory.close()
-
-    # RMSD with shifting
-    u2 = universe_utils.create_universe_single_state(
-        hybrid_system_skipped_pdb, simulation_skipped_nc, 0
-    )
-    prot2 = u2.select_atoms("protein and name CA")
-    apply_transformations.apply_complex_alignment_transformations(u2, protein=prot2)
-
-    R2 = rms.RMSD(prot2)
-    R2.run()
-    rmsd_shift = R2.rmsd[:, 2]
-    assert np.max(np.diff(rmsd_shift[:20])) < 2  # jumps should disappear
-    u2.trajectory.close()
-
-
-def test_rmsd_reference_is_first_frame(universe_single_state):
-    """After alignment, RMSD at the first frame should be zero."""
-    prot = universe_single_state.select_atoms("protein and name CA")
-    apply_transformations.apply_complex_alignment_transformations(
-        universe_single_state, protein=prot
-    )
-
-    _ = next(iter(universe_single_state.trajectory))  # SAFE
-    ref = prot.positions.copy()
-
-    rmsd = np.sqrt(((prot.positions - ref) ** 2).mean())
-    assert rmsd == 0.0
-    universe_single_state.trajectory.close()

--- a/src/openfe_analysis/tests/utils/test_apply_transformations.py
+++ b/src/openfe_analysis/tests/utils/test_apply_transformations.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from itertools import islice
+
+import numpy as np
+import pytest
+from MDAnalysis.analysis import rms
+from MDAnalysis.lib.mdamath import make_whole
+from MDAnalysis.transformations import unwrap
+
+from openfe_analysis.transformations import Aligner
+from openfe_analysis.utils import apply_transformations, universe_utils
+
+
+@pytest.fixture
+def universe_single_state(hybrid_system_skipped_pdb, simulation_skipped_nc):
+    u = universe_utils.create_universe_single_state(
+        hybrid_system_skipped_pdb, simulation_skipped_nc, 0
+    )
+    yield u
+    u.trajectory.close()
+
+
+def test_chain_radius_of_gyration_stable(universe_single_state):
+    """Protein chains should not explode or collapse due to PBC errors
+    after applying alignment transformations."""
+    protein = universe_single_state.select_atoms("protein and name CA")
+    apply_transformations.apply_complex_alignment_transformations(universe_single_state, protein)
+
+    chain = protein.segments[0].atoms
+    rgs = []
+    for ts in universe_single_state.trajectory[:50]:
+        rgs.append(chain.radius_of_gyration())
+
+    assert np.std(rgs) < 2.0
+
+
+def test_ligand_com_continuity(universe_single_state):
+    """Ligand COM should not jump between periodic images after applying
+    alignment transformations."""
+    ligand = universe_single_state.select_atoms("resname UNK")
+    apply_transformations.apply_ligand_alignment_transformations(
+        universe_single_state, ligand=ligand
+    )
+
+    coms = [ligand.center_of_mass() for ts in islice(universe_single_state.trajectory, 20)]
+    jumps = [np.linalg.norm(coms[i + 1] - coms[i]) for i in range(len(coms) - 1)]
+
+    assert max(jumps) < 5.0
+
+
+def test_multichain_rmsd_shifting(simulation_skipped_nc, hybrid_system_skipped_pdb):
+    """Chain shifting should remove RMSD jumps caused by periodic boundary crossings."""
+    u = universe_utils.create_universe_single_state(
+        hybrid_system_skipped_pdb, simulation_skipped_nc, 0
+    )
+    prot = u.select_atoms("protein and name CA")
+    # Do other transformations, but no shifting
+    unwrap_tr = unwrap(prot)
+    for frag in prot.fragments:
+        make_whole(frag, reference_atom=frag[0])
+    align = Aligner(prot)
+    u.trajectory.add_transformations(unwrap_tr, align)
+    chains = [seg.atoms for seg in prot.segments]
+    assert len(chains) > 1, "Test requires multi-chain protein"
+
+    # RMSD without shifting
+    r = rms.RMSD(prot)
+    r.run()
+    rmsd_no_shift = r.rmsd[:, 2]
+    assert np.max(np.diff(rmsd_no_shift[:20])) > 10  # expect jumps
+    u.trajectory.close()
+
+    # RMSD with shifting
+    u2 = universe_utils.create_universe_single_state(
+        hybrid_system_skipped_pdb, simulation_skipped_nc, 0
+    )
+    prot2 = u2.select_atoms("protein and name CA")
+    apply_transformations.apply_complex_alignment_transformations(u2, protein=prot2)
+
+    R2 = rms.RMSD(prot2)
+    R2.run()
+    rmsd_shift = R2.rmsd[:, 2]
+    assert np.max(np.diff(rmsd_shift[:20])) < 2  # jumps should disappear
+    u2.trajectory.close()
+
+
+def test_rmsd_reference_is_first_frame(universe_single_state):
+    """After alignment, RMSD at the first frame should be zero."""
+    prot = universe_single_state.select_atoms("protein and name CA")
+    apply_transformations.apply_complex_alignment_transformations(
+        universe_single_state, protein=prot
+    )
+
+    _ = next(iter(universe_single_state.trajectory))  # SAFE
+    ref = prot.positions.copy()
+
+    rmsd = np.sqrt(((prot.positions - ref) ** 2).mean())
+    assert rmsd == 0.0
+    universe_single_state.trajectory.close()
+
+
+def test_empty_protein_raises(universe_single_state):
+    empty = universe_single_state.select_atoms("resname DOESNOTEXIST")
+    with pytest.raises(ValueError, match="empty or None"):
+        apply_transformations.apply_complex_alignment_transformations(
+            universe_single_state, protein=empty
+        )
+
+
+def test_atomgroup_as_ligands_raises(universe_single_state):
+    prot = universe_single_state.select_atoms("protein and name CA")
+    lig = universe_single_state.select_atoms("resname UNK")
+    with pytest.raises(TypeError, match="list of AtomGroups"):
+        apply_transformations.apply_complex_alignment_transformations(
+            universe_single_state, protein=prot, ligands=lig
+        )
+
+
+def test_empty_ligand_raises(universe_single_state):
+    empty = universe_single_state.select_atoms("resname DOESNOTEXIST")
+    with pytest.raises(ValueError, match="empty or None"):
+        apply_transformations.apply_ligand_alignment_transformations(
+            universe_single_state, ligand=empty
+        )

--- a/src/openfe_analysis/tests/utils/test_universe_utils.py
+++ b/src/openfe_analysis/tests/utils/test_universe_utils.py
@@ -15,7 +15,7 @@ def universe(hybrid_system_skipped_pdb, simulation_skipped_nc):
     )
     prot = universe.select_atoms("protein and name CA")
     ligand = universe.select_atoms("resname UNK")
-    apply_transformations.apply_alignment_transformations(universe, prot, ligand)
+    apply_transformations.apply_complex_alignment_transformations(universe, prot, [ligand])
     yield universe
     universe.trajectory.close()
 
@@ -27,7 +27,7 @@ def ligand_ag(hybrid_system_skipped_pdb, simulation_skipped_nc):
     )
     prot = universe.select_atoms("protein and name CA")
     ligand = universe.select_atoms("resname UNK")
-    apply_transformations.apply_alignment_transformations(universe, prot, ligand)
+    apply_transformations.apply_complex_alignment_transformations(universe, prot, [ligand])
     ag = select_state_atoms(universe, end_state="A").select_atoms("resname UNK")
     yield ag
     universe.trajectory.close()

--- a/src/openfe_analysis/utils/apply_transformations.py
+++ b/src/openfe_analysis/utils/apply_transformations.py
@@ -6,115 +6,98 @@ from MDAnalysis.transformations import unwrap
 from ..transformations import Aligner, ClosestImageShift, NoJump
 
 
-def apply_alignment_transformations(
+def apply_complex_alignment_transformations(
     universe: mda.Universe,
-    protein: mda.AtomGroup | None = None,
-    ligand: mda.AtomGroup | None = None,
+    protein: mda.AtomGroup,
+    ligands: list[mda.AtomGroup] | None = None,
 ) -> None:
     """
-    Apply a standard set of PBC-handling and alignment transformations
-    required for RMSD-based analyses and other structural analyses that
-    assume a pre-processed trajectory.
+    Apply PBC-handling and alignment transformations for complex systems.
 
     Parameters
     ----------
-    universe: mda.Universe
+    universe : mda.Universe
         The Universe the transformations are applied to. Modified in-place.
-    protein: mda.AtomGroup | None
-        The AtomGroup of the protein
-    ligand: mda.AtomGroup | None
-        The AtomGroup of the ligand
+    protein : mda.AtomGroup
+        Protein atoms used for unwrapping, image shifting, and alignment.
+    ligands : list[mda.AtomGroup] | None
+        List of ligand AtomGroups. Each is unwrapped and shifted to the
+        closest image of the protein independently. If None or empty,
+        only the protein is used.
+
+    Raises
+    ------
+    ValueError
+        If ``protein`` is None or contains no atoms.
 
     Notes
     -----
-    Depending on whether a protein is present, a sequence of trajectory
-    transformations is applied:
+    The following transformations are applied in order:
 
-    If a protein is present:
-
-    - Unwraps protein and ligand atom to be made whole
-    - Shifts protein chains and the ligand to the image closest to the first
-      protein chain (:class:`ClosestImageShift`)
+    - Unwraps protein and all ligands to be made whole
+    - Shifts protein chains and each ligand independently to the image
+      closest to the first protein chain (:class:`ClosestImageShift`)
     - Aligns the entire system to minimize the protein RMSD (:class:`Aligner`)
-
-    If only a ligand is present:
-
-    - Prevents the ligand from jumping between periodic images
-    - Aligns the ligand to minimize its RMSD
-
-    If neither protein nor ligand is provided, no transformations are applied.
     """
-    has_protein = protein is not None and protein.n_atoms > 0
-    has_ligand = ligand is not None and ligand.n_atoms > 0
+    if protein is None or protein.n_atoms == 0:
+        raise ValueError("protein AtomGroup is empty or None")
 
-    if has_protein:
-        lig = ligand if has_ligand else None
-        transforms = _transformations_complex(protein, lig)
-    elif has_ligand:
-        transforms = _transformations_ligand_only(ligand)
-    else:
-        return
+    if isinstance(ligands, mda.AtomGroup):
+        raise TypeError(
+            "ligands must be a list of AtomGroups, not a single AtomGroup. "
+            "Use ligands=[ligand] to wrap a single ligand."
+        )
 
-    universe.trajectory.add_transformations(*transforms)
+    ligands = [lig for lig in (ligands or []) if lig.n_atoms > 0]
 
-
-def _transformations_complex(
-    protein: mda.AtomGroup,
-    ligand: mda.AtomGroup | None = None,
-) -> list:
-    """
-    Build transformations for systems containing a protein and optionally
-    a ligand.
-
-    Parameters
-    ----------
-    protein : mda.AtomGroup
-        Protein atoms to use for alignment and image shifting.
-    ligand :  mda.AtomGroup | None
-        Ligand atoms. If provided, included in unwrapping and image shifting.
-
-    Returns
-    -------
-    list
-        Ordered list of trajectory transformations to apply.
-    """
-    transforms = []
+    group = protein
+    for lig in ligands:
+        group = group + lig
     # 1. Make molecules whole (protein + optional ligand)
-    group = protein if ligand is None else protein + ligand
-    transforms.append(unwrap(group))
+    transforms = [unwrap(group)]
 
     # 2. Closest image shift for protein chains + ligand (if present)
     chains = [seg.atoms for seg in protein.segments]
-    shift_targets = chains[1:]
-    if ligand is not None:
-        shift_targets.append(ligand)
+    shift_targets = chains[1:] + ligands
     if shift_targets:
         transforms.append(ClosestImageShift(chains[0], shift_targets))
 
     # 3. Align on protein backbone/atoms
     transforms.append(Aligner(protein))
+    universe.trajectory.add_transformations(*transforms)
 
-    return transforms
 
-
-def _transformations_ligand_only(ligand: mda.AtomGroup) -> list:
+def apply_ligand_alignment_transformations(
+    universe: mda.Universe,
+    ligand: mda.AtomGroup,
+) -> None:
     """
-    Build transformations for ligand-only systems.
+    Apply PBC-handling and alignment transformations for ligand-only systems.
 
     Parameters
     ----------
+    universe : mda.Universe
+        The Universe the transformations are applied to. Modified in-place.
     ligand : mda.AtomGroup
         Ligand atoms to apply transformations to.
 
-    Returns
-    -------
-    list
-        Ordered list of trajectory transformations to apply:
+    Raises
+    ------
+    ValueError
+        If ``ligand`` is None or contains no atoms.
 
-        - Prevent the ligand from jumping between periodic images
-        - Align the ligand to minimize its RMSD
+    Notes
+    -----
+    The following transformations are applied in order:
+
+    - Prevents the ligand from jumping between periodic images
+      (:class:`NoJump`)
+    - Aligns the ligand to minimize its RMSD (:class:`Aligner`)
     """
-    return [
+    if ligand is None or ligand.n_atoms == 0:
+        raise ValueError("ligand AtomGroup is empty or None")
+
+    universe.trajectory.add_transformations(
         NoJump(ligand),
         Aligner(ligand),
-    ]
+    )

--- a/src/openfe_analysis/utils/apply_transformations.py
+++ b/src/openfe_analysis/utils/apply_transformations.py
@@ -20,7 +20,7 @@ def apply_complex_alignment_transformations(
     ----------
     universe: mda.Universe
         The Universe the transformations are applied to. Modified in-place.
-    protein: mda.AtomGroup | None
+    protein: mda.AtomGroup
         The AtomGroup of the protein
     ligands: list[mda.AtomGroup] | None
         List of ligand AtomGroups. Each is unwrapped and shifted to the
@@ -41,7 +41,7 @@ def apply_complex_alignment_transformations(
       closest to the first protein chain (:class:`ClosestImageShift`)
     - Aligns the entire system to minimize the protein RMSD (:class:`Aligner`)
     """
-    if protein is None or protein.n_atoms == 0:
+    if protein is None or not protein:
         raise ValueError("protein AtomGroup is empty or None")
 
     if isinstance(ligands, mda.AtomGroup):
@@ -50,7 +50,7 @@ def apply_complex_alignment_transformations(
             "Use ligands=[ligand] to wrap a single ligand."
         )
 
-    ligands = [lig for lig in (ligands or []) if lig.n_atoms > 0]
+    ligands = [lig for lig in (ligands or []) if lig]
 
     group = protein
     for lig in ligands:

--- a/src/openfe_analysis/utils/apply_transformations.py
+++ b/src/openfe_analysis/utils/apply_transformations.py
@@ -12,15 +12,17 @@ def apply_complex_alignment_transformations(
     ligands: list[mda.AtomGroup] | None = None,
 ) -> None:
     """
-    Apply PBC-handling and alignment transformations for complex systems.
+    Apply a standard set of PBC-handling and alignment transformations
+    required for RMSD-based analyses and other structural analyses that
+    assume a pre-processed trajectory.
 
     Parameters
     ----------
-    universe : mda.Universe
+    universe: mda.Universe
         The Universe the transformations are applied to. Modified in-place.
-    protein : mda.AtomGroup
-        Protein atoms used for unwrapping, image shifting, and alignment.
-    ligands : list[mda.AtomGroup] | None
+    protein: mda.AtomGroup | None
+        The AtomGroup of the protein
+    ligands: list[mda.AtomGroup] | None
         List of ligand AtomGroups. Each is unwrapped and shifted to the
         closest image of the protein independently. If None or empty,
         only the protein is used.


### PR DESCRIPTION
I was working on adding the structural analysis to the SepTop protocol and I realized that when I pass the ligands to the alignement as a combined atomgroup, but one ligand is in a different image than the other ligand, this can lead to spiked in the RMSD. I changed the alignment, now allowing passing in a list of AtomGroups for the ligands.